### PR TITLE
Filter out empty values from settings keys prior to building runtime options

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/sbt/ScapegoatSbtPlugin.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/sbt/ScapegoatSbtPlugin.scala
@@ -52,15 +52,15 @@ object ScapegoatSbtPlugin extends AutoPlugin {
           if (verbose)
             streams.value.log.info(s"[scapegoat] setting output dir to [$path]")
 
-          val disabled = scapegoatDisabledInspections.value
+          val disabled = scapegoatDisabledInspections.value.filterNot(_.trim.isEmpty)
           if (disabled.size > 0 && verbose)
             streams.value.log.info("[scapegoat] disabled inspections: " + disabled.mkString(","))
 
-          val enabled = scapegoatEnabledInspections.value
+          val enabled = scapegoatEnabledInspections.value.filterNot(_.trim.isEmpty)
           if (enabled.size > 0 && verbose)
             streams.value.log.info("[scapegoat] enabled inspections: " + enabled.mkString(","))
 
-          val ignoredFilePatterns = scapegoatIgnoredFiles.value
+          val ignoredFilePatterns = scapegoatIgnoredFiles.value.filterNot(_.trim.isEmpty)
           if (ignoredFilePatterns.size > 0 && verbose)
             streams.value.log.info("[scapegoat] ignored file patterns: " + ignoredFilePatterns.mkString(","))
 


### PR DESCRIPTION
Filtering out the empty options from the `disabledInspections`, `enabledInspections` and `ignoredFiles` keys prior to their usage.
