### PR TITLE
 Add enabledInspections setting

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/sbt/ScapegoatSbtPlugin.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/sbt/ScapegoatSbtPlugin.scala
@@ -82,10 +82,10 @@ object ScapegoatSbtPlugin extends AutoPlugin {
                 if (disabled.nonEmpty && verbose)
                   streamsValue.log.info("[scapegoat] disabled inspections: " + disabled.mkString(","))
 
-                // if inspection is present in enabled and disabled then disabled takes priority
+                // disabledInspections takes precedence over enabledInspections
                 val enabled = scapegoatEnabledInspections.value.filterNot(s => s.trim.isEmpty)
                 if(enabled.nonEmpty && verbose)
-                  streamsValue.log.info("[scapegoat] enabled inspections: " + disabled.mkString(","))
+                  streamsValue.log.info("[scapegoat] enabled inspections: " + enabled.mkString(","))
 
                 val ignoredFilePatterns = scapegoatIgnoredFiles.value.filterNot(_.trim.isEmpty)
                 if (ignoredFilePatterns.nonEmpty && verbose)

--- a/src/main/scala/com/sksamuel/scapegoat/sbt/ScapegoatSbtPlugin.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/sbt/ScapegoatSbtPlugin.scala
@@ -50,6 +50,7 @@ object ScapegoatSbtPlugin extends AutoPlugin {
     scapegoatMaxWarnings := -1,
     scapegoatMaxErrors := -1,
     scapegoatDisabledInspections := Nil,
+    scapegoatEnabledInspections := Nil,
     scapegoatIgnoredFiles := Nil,
     scapegoatReports := Seq("all"),
     scapegoatSourcePrefix := "src/main/scala",

--- a/src/main/scala/com/sksamuel/scapegoat/sbt/ScapegoatSbtPlugin.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/sbt/ScapegoatSbtPlugin.scala
@@ -16,6 +16,7 @@ object ScapegoatSbtPlugin extends AutoPlugin {
     lazy val scapegoatClean = taskKey[Unit]("Clean the scapegoat output directories")
     lazy val scapegoatVersion = settingKey[String]("The version of the scala plugin to use")
     lazy val scapegoatDisabledInspections = settingKey[Seq[String]]("Inspections that are disabled globally")
+    lazy val scapegoatEnabledInspections = settingKey[Seq[String]]("Inspections that are enabled globally")
     lazy val scapegoatRunAlways = settingKey[Boolean]("Force inspections to run even on files that haven't changed")
     lazy val scapegoatIgnoredFiles = settingKey[Seq[String]]("File patterns to ignore")
     lazy val scapegoatMaxErrors = settingKey[Int]("Maximum number of errors before the build will fail")
@@ -81,6 +82,11 @@ object ScapegoatSbtPlugin extends AutoPlugin {
                 if (disabled.nonEmpty && verbose)
                   streamsValue.log.info("[scapegoat] disabled inspections: " + disabled.mkString(","))
 
+                // if inspection is present in enabled and disabled then disabled takes priority
+                val enabled = scapegoatEnabledInspections.value.filterNot(s => s.trim.isEmpty)
+                if(enabled.nonEmpty && verbose)
+                  streamsValue.log.info("[scapegoat] enabled inspections: " + disabled.mkString(","))
+
                 val ignoredFilePatterns = scapegoatIgnoredFiles.value.filterNot(_.trim.isEmpty)
                 if (ignoredFilePatterns.nonEmpty && verbose)
                   streamsValue.log.info("[scapegoat] ignored file patterns: " + ignoredFilePatterns.mkString(","))
@@ -98,6 +104,7 @@ object ScapegoatSbtPlugin extends AutoPlugin {
                   Some("-P:scapegoat:verbose:" + scapegoatVerbose.value),
                   Some("-P:scapegoat:consoleOutput:" + scapegoatConsoleOutput.value),
                   Some("-P:scapegoat:dataDir:" + path),
+                  if (enabled.isEmpty) None else Some("-P:scapegoat:enabledInspections:" + enabled.mkString(":")),
                   if (disabled.isEmpty) None else Some("-P:scapegoat:disabledInspections:" + disabled.mkString(":")),
                   if (ignoredFilePatterns.isEmpty) None else Some("-P:scapegoat:ignoredFiles:" + ignoredFilePatterns.mkString(":")),
                   if (reports.isEmpty) None else Some("-P:scapegoat:reports:" + reports.mkString(":")),


### PR DESCRIPTION
Currently we have `disabledInspections` setting to disable the inspections.
To support incremental enable of rules we can use the  [enabledInspections](https://github.com/scapegoat-scala/scapegoat/blob/2cbbf7971240d47807d3f274739807a6a7be71e8/src/main/scala/com/sksamuel/scapegoat/Configuration.scala#L109) setting to enable certain set of rules.
`disabledInspections` takes precedence over `enabledInspections`



