### PR TITLE
Fix the configured compiler setting for Minimal Warn Level

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/sbt/ScapegoatSbtPlugin.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/sbt/ScapegoatSbtPlugin.scala
@@ -110,7 +110,7 @@ object ScapegoatSbtPlugin extends AutoPlugin {
                   if (ignoredFilePatterns.isEmpty) None else Some("-P:scapegoat:ignoredFiles:" + ignoredFilePatterns.mkString(":")),
                   if (reports.isEmpty) None else Some("-P:scapegoat:reports:" + reports.mkString(":")),
                   if (customSourcePrefix.isEmpty) None else Some(s"-P:scapegoat:sourcePrefix:$customSourcePrefix"),
-                  if (customMinimalWarnLevel.isEmpty) None else Some(s"-P:scapegoat:minimalWarnLevel:$customMinimalWarnLevel")).flatten
+                  if (customMinimalWarnLevel.isEmpty) None else Some(s"-P:scapegoat:minimalLevel:$customMinimalWarnLevel")).flatten
             }
           })
     } ++ Seq(


### PR DESCRIPTION
The compiler setting scapegoat expect seems to always have been `minimalLevel`. The Setting was introduced in scapegoat with https://github.com/scapegoat-scala/scapegoat/pull/243 but the help text was wrong at the time. The help text was corrected in https://github.com/scapegoat-scala/scapegoat/pull/490.
So I can't find a historical ref that scapegoat actually expected minimalWarnLevel. Thus I think we can just simply replace the setting and no need to check the scapegaoat version to decide.