### PR TITLE
Align release process with scapegoat

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: Release
+on:
+  push:
+    branches: [master]
+    tags: ["*"]
+jobs:
+  release:
+    runs-on: ubuntu-20.04
+    if: github.repository == 'scapegoat-scala/sbt-scapegoat'
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: olafurpg/setup-scala@v14
+        with:
+          java-version: adopt@1.8
+      - run: sbt ci-release
+        env:
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,17 +15,8 @@ jobs:
         with:
           java-version: adopt@1.8
       - run: |
-          mkdir ~/.gnupg && chmod 700 ~/.gnupg
-          echo use-agent >> ~/.gnupg/gpg.conf
-          echo pinentry-mode loopback >> ~/.gnupg/gpg.conf
-          echo allow-loopback-pinentry >> ~/.gnupg/gpg-agent.conf
-          chmod 600 ~/.gnupg/*
-          echo RELOADAGENT | gpg-connect-agent
           echo ${PGP_SECRET:0:4}...${PGP_SECRET: -4}
-          echo $PGP_SECRET | base64 --decode | gpg --import --no-tty --batch --yes
-        env:
-          PGP_SECRET: ${{secrets.PGP_SECRET}}
-      - run: sbt ci-release
+          sbt ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,17 @@ jobs:
       - uses: olafurpg/setup-scala@v14
         with:
           java-version: adopt@1.8
+      - run: |
+          sudo apt-get update && sudo apt-get -y install gnupg2
+          mkdir ~/.gnupg && chmod 700 ~/.gnupg
+          echo use-agent >> ~/.gnupg/gpg.conf
+          echo pinentry-mode loopback >> ~/.gnupg/gpg.conf
+          echo allow-loopback-pinentry >> ~/.gnupg/gpg-agent.conf
+          chmod 600 ~/.gnupg/*
+          echo RELOADAGENT | gpg-connect-agent
+          echo $PGP_SECRET | base64 --decode | gpg --import --no-tty --batch --yes
+        env:
+          PGP_SECRET: ${{secrets.PGP_SECRET}}
       - run: sbt ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,13 +15,13 @@ jobs:
         with:
           java-version: adopt@1.8
       - run: |
-          sudo apt-get update && sudo apt-get -y install gnupg2
           mkdir ~/.gnupg && chmod 700 ~/.gnupg
           echo use-agent >> ~/.gnupg/gpg.conf
           echo pinentry-mode loopback >> ~/.gnupg/gpg.conf
           echo allow-loopback-pinentry >> ~/.gnupg/gpg-agent.conf
           chmod 600 ~/.gnupg/*
           echo RELOADAGENT | gpg-connect-agent
+          echo ${PGP_SECRET:0:4}...${PGP_SECRET: -4}
           echo $PGP_SECRET | base64 --decode | gpg --import --no-tty --batch --yes
         env:
           PGP_SECRET: ${{secrets.PGP_SECRET}}

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ src_managed/
 project/boot/
 project/plugins/project/
 credentials.sbt
+.bsp/
 
 # Scala-IDE specific
 .scala_dependencies

--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,24 @@
-import sbtrelease.ReleaseStateTransformations._
-
 name := "sbt-scapegoat"
-
 organization := "com.sksamuel.scapegoat"
+homepage := Some(url("https://github.com/scapegoat-scala/sbt-scapegoat"))
+licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html"))
+scmInfo := Some(
+  ScmInfo(
+    url("https://github.com/scapegoat-scala/sbt-scapegoat"),
+    "scm:git@github.com:scapegoat-scala/sbt-scapegoat.git",
+    Some("scm:git@github.com:scapegoat-scala/sbt-scapegoat.git")
+  )
+)
+developers := List(
+  Developer(
+    "sksamuel",
+    "sksamuel",
+    "@sksamuel",
+    url("https://github.com/sksamuel")
+  )
+)
 
 scalacOptions := Seq("-unchecked", "-deprecation", "-feature", "-encoding", "utf8")
-
 javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
 
 // Align Scala (major) version and SBT versions
@@ -16,67 +29,9 @@ sbtPlugin := true
 
 crossSbtVersions := Seq("0.13.18", "1.5.8")
 
-publishMavenStyle := true
+Test / publishArtifact := false
+Test / parallelExecution := false
 
-publishArtifact in Test := false
+sonatypeCredentialHost := "s01.oss.sonatype.org"
+sonatypeRepository := "https://s01.oss.sonatype.org/service/local"
 
-pomIncludeRepository := Function.const(false)
-
-releaseCrossBuild := true
-
-releasePublishArtifactsAction := PgpKeys.publishSigned.value
-
-publishTo := {
-  val nexus = "https://s01.oss.sonatype.org/"
-  Some("releases" at nexus + "service/local/staging/deploy/maven2")
-}
-
-val localCreds = Credentials(Path.userHome / ".sbt" / "credentials.sbt")
-
-credentials := Seq(localCreds)
-
-parallelExecution in Test := false
-
-releaseProcess := Seq[ReleaseStep](
-  checkSnapshotDependencies,
-  inquireVersions,
-  runClean,
-  releaseStepCommandAndRemaining("^test"),
-  setReleaseVersion,
-  commitReleaseVersion,
-  tagRelease,
-  releaseStepCommandAndRemaining("^publish"),
-  setNextVersion,
-  commitNextVersion,
-  pushChanges
-)
-
-pgpSecretRing := file("/home/sam/Downloads/gpg.private")
-
-pgpPublicRing := file("/home/sam/Downloads/gpg.public")
-
-pomIncludeRepository := {
-  _ => false
-}
-
-pomExtra := {
-  <url>https://github.com/sksamuel/sbt-scapegoat</url>
-    <licenses>
-      <license>
-        <name>Apache 2</name>
-        <url>http://www.apache.org/licenses/LICENSE-2.0</url>
-        <distribution>repo</distribution>
-      </license>
-    </licenses>
-    <scm>
-      <url>git@github.com:sksamuel/sbt-scapegoat.git</url>
-      <connection>scm:git@github.com:sksamuel/sbt-scapegoat.git</connection>
-    </scm>
-    <developers>
-      <developer>
-        <id>sksamuel</id>
-        <name>sksamuel</name>
-        <url>http://github.com/sksamuel</url>
-      </developer>
-    </developers>
-}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,4 @@
 resolvers += Classpaths.sbtPluginReleases
 
-addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
-
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
-
-addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.11")

--- a/sonatype.sbt
+++ b/sonatype.sbt
@@ -1,0 +1,1 @@
+sonatypeProfileName := "com.sksamuel"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,0 @@
-ThisBuild / version := "1.1.2-SNAPSHOT"


### PR DESCRIPTION
To simplify the release processes across repos, I propose to align sbt-scapegoat with scapegoat. With this change both are published based on tags through CI.
This should also help to get release process clearer and get releases for sbt-scapegoat going again.