### PR TITLE
Read scapegoatVersion from ThisProject context

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,17 @@ class Test2 {
 } 
 ```
 
+#### Cross build for Scala 2.11
+
+```scala
+scapegoatVersion := {
+  CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((2, 11)) => "1.4.9"
+    case _ => "2.1.1"
+  }
+}
+```
+
 #### Inspection warning level overrides
 
 If you want to change the warning level of an inspection, for example to downgrade "TraversableHead" and "OptionGet" from Errors to Warnings, add the following to your build.sbt:

--- a/src/main/scala/com/sksamuel/scapegoat/sbt/ScapegoatSbtPlugin.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/sbt/ScapegoatSbtPlugin.scala
@@ -116,7 +116,7 @@ object ScapegoatSbtPlugin extends AutoPlugin {
     } ++ Seq(
       (compile in Scapegoat) := ((compile in Scapegoat) dependsOn scapegoatClean).value,
       scapegoat := (compile in Scapegoat).value,
-      scapegoatCleanTask := doScapegoatClean((scapegoatRunAlways in ThisProject).value, (classDirectory in Scapegoat).value, streams.value.log),
+      scapegoatCleanTask := doScapegoatClean((scapegoatRunAlways in ThisBuild).value, (classDirectory in Scapegoat).value, streams.value.log),
       scapegoatClean := doScapegoatClean(true, (classDirectory in Scapegoat).value, streams.value.log),
       // FIXME Cannot seem to make this a build setting (compile:crossTarget is an undefined setting)
       scapegoatOutputPath := (crossTarget in Compile).value.getAbsolutePath + "/scapegoat-report",

--- a/src/main/scala/com/sksamuel/scapegoat/sbt/ScapegoatSbtPlugin.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/sbt/ScapegoatSbtPlugin.scala
@@ -116,11 +116,11 @@ object ScapegoatSbtPlugin extends AutoPlugin {
     } ++ Seq(
       (compile in Scapegoat) := ((compile in Scapegoat) dependsOn scapegoatClean).value,
       scapegoat := (compile in Scapegoat).value,
-      scapegoatCleanTask := doScapegoatClean((scapegoatRunAlways in ThisBuild).value, (classDirectory in Scapegoat).value, streams.value.log),
+      scapegoatCleanTask := doScapegoatClean((scapegoatRunAlways in ThisProject).value, (classDirectory in Scapegoat).value, streams.value.log),
       scapegoatClean := doScapegoatClean(true, (classDirectory in Scapegoat).value, streams.value.log),
       // FIXME Cannot seem to make this a build setting (compile:crossTarget is an undefined setting)
       scapegoatOutputPath := (crossTarget in Compile).value.getAbsolutePath + "/scapegoat-report",
-      libraryDependencies ++= Seq(crossVersion(GroupId %% ArtifactId % (scapegoatVersion in ThisBuild).value % Provided)))
+      libraryDependencies ++= Seq(crossVersion(GroupId %% ArtifactId % (scapegoatVersion in ThisProject).value % Provided)))
   }
 
   private def crossVersion(mod: ModuleID) = {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "1.1.2-SNAPSHOT"
+ThisBuild / version := "1.1.2"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "1.1.2"
+ThisBuild / version := "1.1.2-SNAPSHOT"


### PR DESCRIPTION
Build file example

```scala
enablePlugins(ScapegoatSbtPlugin)

val scala211Version = "2.11.12"
val scala212Version = "2.12.17"
val scala213Version = "2.13.10"

lazy val root = project
  .in(file("."))
  .settings(
    name := "scapegoat-example",
    scalaVersion := scala213Version,
    crossScalaVersions := Seq(
      scala211Version,
      scala212Version,
      scala213Version,
    ),
    scapegoatVersion := {
      CrossVersion.partialVersion(scalaVersion.value) match {
        case Some((2, 11)) => "1.4.9"
        case _ => "2.1.1"
      }
    }
  )
```