### PR TITLE
chore: Switch to scalafmt to get a less intrusive formatter

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,6 @@
+version = 3.8.3
+runner.dialect = scala212
+maxColumn = 120
+align.preset = none
+rewrite.trailingCommas.style = always
+

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 resolvers += Classpaths.sbtPluginReleases
 
-addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.7.0")


### PR DESCRIPTION
While trying to fix double compile the scalariform formatting caused more iterations due to copying lines being more prone to cause syntax errors. As it's not maintained anymore switch to scalafmt.